### PR TITLE
Fix the dependency conflict issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.8.1</version>
+			<version>3.14.4</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Fix the dependency conflict issue #12 by Solution2 Declare version com.squareup.okhttp3:okhttp:3.14.4 as a direct dependency.